### PR TITLE
Initial script to scrape US Visa bulletin data. Aim: Plot lag for employment-based visas for different country categories. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# artifacts 
+cache/
+*.png*
+
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ options:
   -h, --help            show this help message and exit
   -c COUNTRY_CATEGORY, --country-category COUNTRY_CATEGORY
                         Country category.
-                        IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN default.
+                        IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN
+                        default.
+  -s START_YEAR, --start-year START_YEAR
+                        Year to start analysis. Should be >= 2001.
+  -e END_YEAR, --end-year END_YEAR
+                        Year to end analysis. Should be <= current year.
 ```
 
 The final artifact of this script is an image created in the images directory for the country category you provided. 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,19 @@ This script plots the lag period (the time between the visa bulletin date and th
 
 To run: 
 ```
-python3 visa-bulletin-scraper.py
+$ python3 visa-bulletin-scraper.py --help
+
+usage: US Visa bulletin data scraper and data visualisation [-h] [-c COUNTRY_CATEGORY]
+
+This program will take arguments relating to country category and display thelag time for
+being eligible to apply for a green card for the first three employment categoriesfor that
+country category.
+
+options:
+  -h, --help            show this help message and exit
+  -c COUNTRY_CATEGORY, --country-category COUNTRY_CATEGORY
+                        Country category.
+                        IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN default.
 ```
 
-The final artifact of this script is a plot. 
+The final artifact of this script is an image created in the images directory for the country category you provided. 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # us-visa-analysis
-Some scripts to help me analyse different (publicly available) US visa data.
+
+Some scripts to help me analyse (publicly available) US visa data.
+
+## 1. visa-bulletin-scraper.py
+I'd like to write some scripts to help visualise Employment-based visa status for the US over the years, for different country categories (India, China, Mexico, RoW). This is purely for my own information.  
+
+This script plots the lag period (the time between the visa bulletin date and the date specified in the visa bulletin for different countries/employment-based visa categories), if any. If the table shows 'C', that means that the visa category is 'Current' for that country category, i.e. once the Visa/PERM is approved, the applicant can immediately apply for a Green Card/ there is one already available for the applicant. If the date is not yet 'Current' but is some time in the past, the applicant must wait once the PERM is approved for that date to become equal to the applicant's Priority Date. Once that condition is met, the applicant can proceed in the Green Card process. 
+
+To run: 
+```
+python3 visa-bulletin-scraper.py
+```
+
+The final artifact of this script is a plot. 

--- a/visa-bulletin-scraper.py
+++ b/visa-bulletin-scraper.py
@@ -154,11 +154,13 @@ if __name__ == "__main__":
                     description='This program will take arguments relating to country category and display the'
                     'lag time for being eligible to apply for a green card for the first three employment categories'
                     'for that country category.')
-    parser.add_argument('-c', '--country-category', default="IN", help='Country category. IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN default.')
+    parser.add_argument('-c', '--country-category', type=str, default="IN", help='Country category. IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN default.')
+    parser.add_argument('-s', '--start-year', type=int, default=2002, help='Year to start analysis. Should be > 1998.')
+    parser.add_argument('-e', '--end-year', type=int, default=2025, help='Year to end analysis.')
     args = parser.parse_args()
 
     base_url = "https://travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin"  # Base URL
-    years = range(2002, 2025)  # Years to process
+    years = range(args.start_year, args.end_year)  # Years to process
     months = ["january", "february", "march", "april", "may", "june",
               "july", "august", "september", "october", "november", "december"]
 
@@ -241,7 +243,7 @@ if __name__ == "__main__":
 
     # Validate data and plot
     if lag_data and all(len(lags) == len(month_labels) for lags in lag_data.values()):
-        plot_lag(lag_data, month_labels, f"Lag Trends for '{column_of_interest}' Column")
+        plot_lag(lag_data, month_labels, f"Lag Trends for '{column_of_interest}' Column From {args.start_year} To {args.end_year}")
     else:
         print("Error: Data length mismatch.")
         print(f"Month labels length: {len(month_labels)}")

--- a/visa-bulletin-scraper.py
+++ b/visa-bulletin-scraper.py
@@ -1,0 +1,197 @@
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+from datetime import datetime
+import hashlib
+
+def fetch_or_cache(url, folder="cache"):
+    """
+    Fetch data from the URL or load from cache if it already exists.
+
+    Args:
+        url (str): The URL to fetch data from.
+        folder (str): The folder to save cached data.
+
+    Returns:
+        str: The content of the URL (from cache or web).
+    """
+    # Ensure the cache folder exists
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+
+    # Create a unique filename for the URL
+    url_hash = hashlib.md5(url.encode()).hexdigest()
+    file_path = os.path.join(folder, f"{url_hash}.html")
+
+    # Check if the file exists in the cache
+    if os.path.exists(file_path):
+        print(f"Loading cached data for {url}")
+        with open(file_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    # Otherwise, fetch the data and save it to the cache
+    print(f"Fetching data from {url}")
+    response = requests.get(url)
+    if response.status_code != 200:
+        print(f"Failed to fetch {url}: {response.status_code}")
+        return None
+    content = response.text
+
+    # Save the content to the file
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    return content
+
+# def fetch_url_data(url):
+#     response = requests.get(url)
+#     if response.status_code != 200:
+#         print(f"Failed to fetch {url}")
+#         return None
+#     return response
+
+# Function to fetch table data from the webpage
+def fetch_table_data(content, table_identifier):
+    soup = BeautifulSoup(content, 'html.parser')
+    tables = soup.find_all('table')
+    
+    for table in tables:
+        # Collect headers from the first row(s) of the table
+        headers = []
+        for header_row in table.find_all('tr'):
+            row_headers = [cell.get_text(strip=True).replace('\n', ' ') for cell in header_row.find_all(['th', 'td'])]
+            if row_headers:
+                headers.extend(row_headers)
+        
+        # Check if table_identifier is in the flattened headers
+        headers_text = " ".join(headers).strip()
+        if table_identifier.lower() in headers_text.lower():  # Match case-insensitively
+            rows = table.find_all('tr')
+            data = []
+            for row in rows[1:]:  # Skip header row(s)
+                cells = row.find_all(['td', 'th'])
+                data.append([cell.get_text(strip=True).replace('\n', ' ') for cell in cells])
+            df = pd.DataFrame(data, columns=headers[:len(data[0])])
+            return df  # Return the DataFrame
+    
+    print(f"Table with identifier '{table_identifier}' not found.")
+    return None
+
+# Function to parse date and calculate lag
+def calculate_lag(df, column, base_date):
+    if column not in df.columns:
+        print(f"Column '{column}' not found in table for {base_date}")
+        print(f"This was a good year for {column}")
+        column = "All Chargeability Areas Except Those Listed"
+        if column not in df.columns:
+            print(f"Something is really wrong because even {column} isn't present in Table")
+            return None
+        
+    
+    lags = {}
+    for index, value in df[column].items():
+        print(f"Index: {index}, value: {value}")
+        if value == "C":  # 'Current' means zero backlog
+            lags[df.iloc[index, 0]] = 0
+        else:
+            try:
+                backlog_date = datetime.strptime(value, "%d%b%y")  # Parse date like '01JAN20'
+                lag = (base_date - backlog_date).days
+                lags[df.iloc[index, 0]] = lag
+            except ValueError:
+                lags[df.iloc[index, 0]] = None  # Handle invalid/missing data gracefully
+    return lags
+
+# Plotting function
+def plot_lag(data, months, title):
+    plt.figure(figsize=(12, 6))
+    for row, lags in data.items():
+        plt.plot(months, lags, label=row)
+    plt.title(title)
+    plt.xlabel("Month")
+    plt.ylabel("Lag (Days)")
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    plt.grid()
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    base_url = "https://travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin"  # Base URL
+    years = range(2002, 2024)  # Years to process
+    months = ["january", "february", "march", "april", "may", "june",
+              "july", "august", "september", "october", "november", "december"]
+
+    table_identifier = "Employment-based"  # Header to identify the table
+    column_of_interest = "INDIA" # input("Enter the column of interest (or press Enter to fetch full table): ")
+    lag_data = {}
+    month_labels = []
+
+    for year in years:
+        for month in months:
+            if month in ["october", "november", "december"]:
+                url = f"{base_url}/{year+1}/visa-bulletin-for-{month}-{year}.html"
+            else:
+                url = f"{base_url}/{year}/visa-bulletin-for-{month}-{year}.html"
+            # fetch data from url
+            response = fetch_or_cache(url)
+
+            if response is None:
+                print(f"Let's try removing the 'for' in the url")
+                if month in ["october", "november", "december"]:
+                    url = f"{base_url}/{year+1}/visa-bulletin-{month}-{year}.html"
+                else:
+                    url = f"{base_url}/{year}/visa-bulletin-{month}-{year}.html" 
+                response = fetch_or_cache(url)
+
+            if response is None:
+                print(f"Let's try swapping the years!")
+                if month in ["october", "november", "december"]:
+                    url = f"{base_url}/{year}/visa-bulletin-for-{month}-{year}.html"
+                else:
+                    url = f"{base_url}/{year+1}/visa-bulletin-for-{month}-{year}.html"
+                response = fetch_or_cache(url)
+                            
+            if response is None:
+                print("unable to fetch data from {url}; skipping")
+                continue
+
+            table = fetch_table_data(response, table_identifier)
+            
+            if table is not None:  # Ensure table exists
+                base_date = datetime.strptime(f"01{month[:3]}{year}", "%d%b%Y")
+                lags = calculate_lag(table, column_of_interest, base_date)
+                if lags:
+                    # Add data to lag_data
+                    for row, lag in lags.items():
+                        if row not in lag_data:
+                            lag_data[row] = [None] * len(month_labels)  # Fill missing months with None
+                        lag_data[row].append(lag)
+                    # Add placeholders for rows not in lags
+                    for row in lag_data:
+                        if row not in lags:
+                            lag_data[row].append(None)
+                    month_labels.append(f"{month[:3]} {year}")  # Append valid month-year
+            else:
+                # If no table, append None for all rows
+                for row in lag_data:
+                    lag_data[row].append(None)
+                print(f"No table found for {month} {year}. Skipping.")
+
+    # Ensure all rows have the same length as month_labels
+    for row in lag_data:
+        if len(lag_data[row]) < len(month_labels):
+            lag_data[row].extend([None] * (len(month_labels) - len(lag_data[row])))
+
+    # Validate data and plot
+    if lag_data and all(len(lags) == len(month_labels) for lags in lag_data.values()):
+        plot_lag(lag_data, month_labels, f"Lag Trends for '{column_of_interest}' Column")
+    else:
+        print("Error: Data length mismatch.")
+        print(f"Month labels length: {len(month_labels)}")
+        for row, lags in lag_data.items():
+            print(f"Row: {row}, Lag data length: {len(lags)}")
+

--- a/visa-bulletin-scraper.py
+++ b/visa-bulletin-scraper.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
                     description='This program will take arguments relating to country category and display the'
                     'lag time for being eligible to apply for a green card for the first three employment categories'
                     'for that country category.')
-    parser.add_argument('-c', '--country-category', default="IN", help='Country category. IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All')
+    parser.add_argument('-c', '--country-category', default="IN", help='Country category. IN(India)/CH(China)/ME(Mexico)/PH(Phillipines)/V(Vietnam)/All. IN default.')
     args = parser.parse_args()
 
     base_url = "https://travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin"  # Base URL

--- a/visa-bulletin-scraper.py
+++ b/visa-bulletin-scraper.py
@@ -7,6 +7,9 @@ import os
 from datetime import datetime
 import hashlib
 
+
+images_dir = "images"
+
 def fetch_or_cache(url, folder="cache"):
     """
     Fetch data from the URL or load from cache if it already exists.
@@ -102,21 +105,6 @@ def calculate_lag(df, column, base_date):
 
 # Plotting function
 def plot_lag(data, months, title):
-    """
-    plt.figure(figsize=(12, 6))
-    for row, lags in data.items():
-        plt.plot(months, lags, label=row)
-    plt.title(title)
-    plt.xlabel("Month")
-    plt.ylabel("Lag (Days)")
-    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-    plt.grid()
-    plt.xticks(rotation=45)
-    plt.tight_layout()
-    # plt.show()
-    plt.savefig('visa-bulletin-india.png')
-    # plt.savefig('foo.pdf')
-    """
     plt.figure(figsize=(14, 8))
 
     # Convert month_labels to datetime if not already
@@ -140,8 +128,11 @@ def plot_lag(data, months, title):
     plt.grid(visible=True, which="both", linestyle="--", linewidth=0.5)
     plt.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
     plt.tight_layout()
-    # plt.show()
-    plt.savefig('visa-bulletin-india.png')
+    image_name = title.lower().replace(" ", "_").replace("'", "") + ".png"
+    if not os.path.exists(images_dir):
+        os.makedirs(images_dir)
+    
+    plt.savefig(os.path.join(images_dir, image_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add initial data that will scrape US Visa bulletin every month, and plot the lag period for different employment based categories for different Country categories - India, China, Mexico and RoW.

What's done: 
- Reaches out to US govt. data publicly available, to find the monthly visa bulletin for the range of years specified (currently hardcoded).
- Caches the html pages so that this scraper is not repeatedly pinging the US visa bulletin website. 
- Handles subtleties in the Visa bulletin URLs. 
- Provide different country categories to search through 
- Takes year-range 

What's not done/may not be done:
- Cannot plot over different country-categories keeping the Employment-based category the same.
- Doesn't take specific employment-based category as args.